### PR TITLE
fix(exec): allow opt-in PermissionRequest/Notification hooks

### DIFF
--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -89,7 +89,9 @@ struct ThreadEventEnvelope {
     event: Event,
 }
 
-fn approval_policy_override_for_exec<T>(cli_kv_overrides: &[(String, T)]) -> Option<AskForApproval> {
+fn approval_policy_override_for_exec<T>(
+    cli_kv_overrides: &[(String, T)],
+) -> Option<AskForApproval> {
     if cli_kv_overrides
         .iter()
         .any(|(key, _value)| key == "approval_policy")


### PR DESCRIPTION
背景：`codex exec` 之前强制 `approval_policy=never`，导致 PermissionRequest/Notification 的 hook dispatch 路径永远走不到（无法覆盖/验证这两个 hook 事件）。

改动：
- `codex exec` 默认仍保持 headless 模式不请求审批（行为不变）。
- 当用户显式通过 `-c approval_policy=...` 覆盖时，不再强制 `never`，从而允许 core 进入 `request_command_approval()` 并触发 PermissionRequest/Notification hooks。
- exec 模式收到 `ExecApprovalRequest` / `ApplyPatchApprovalRequest` 时自动回 `Denied`，避免无 UI 情况下卡死。

测试：`cd codex-rs && just fmt && cargo test -p codex-exec`