### PR TITLE
ci(bazel): pass Codex CLI version

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -160,6 +160,14 @@ jobs:
             --build_metadata=VISIBILITY=PUBLIC
           )
 
+          codex_cli_version="$(grep -m1 '^version' codex-rs/Cargo.toml \
+            | sed -E 's/version *= *"([^"]+)".*/\1/')"
+          if [[ -z "${codex_cli_version}" ]]; then
+            echo "Failed to parse codex-rs/Cargo.toml version" >&2
+            exit 1
+          fi
+          bazel_args+=("--action_env=CODEX_CLI_VERSION=${codex_cli_version}")
+
           if [[ "${RUNNER_OS:-}" != "Windows" ]]; then
             # Bazel test sandboxes on macOS may resolve an older Homebrew `node`
             # before the `actions/setup-node` runtime on PATH.

--- a/codex-rs/tui/src/version.rs
+++ b/codex-rs/tui/src/version.rs
@@ -1,2 +1,5 @@
 /// The current Codex CLI version as embedded at compile time.
-pub const CODEX_CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CODEX_CLI_VERSION: &str = match option_env!("CODEX_CLI_VERSION") {
+    Some(version) => version,
+    None => env!("CARGO_PKG_VERSION"),
+};


### PR DESCRIPTION
Fixes Bazel (experimental) snapshot failures on main by passing the Cargo.toml version into Bazel actions (CODEX_CLI_VERSION) and preferring that value in the TUI version banner when present.