### PR TITLE
fix(agent-teams): avoid misleading NotFound in wait_team

### DIFF
--- a/codex-rs/core/src/tools/handlers/multi_agents/tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/tests.rs
@@ -4,6 +4,7 @@ use crate::CodexAuth;
 use crate::ThreadManager;
 use crate::built_in_model_providers;
 use crate::codex::make_session_and_context;
+use crate::codex::make_session_and_context_with_rx;
 use crate::config::types::ShellEnvironmentPolicy;
 use crate::function_tool::FunctionCallError;
 use crate::protocol::AskForApproval;
@@ -2542,6 +2543,105 @@ async fn spawn_team_wait_team_and_close_team_flow() {
         .is_err(),
         true
     );
+}
+
+#[tokio::test]
+async fn wait_team_any_includes_non_final_member_statuses_in_events() {
+    let (mut session, turn, rx) = make_session_and_context_with_rx().await;
+    let manager = thread_manager();
+    Arc::get_mut(&mut session)
+        .expect("session should be unique")
+        .services
+        .agent_control = manager.agent_control();
+
+    let spawn_output = MultiAgentHandler
+        .handle(invocation(
+            session.clone(),
+            turn.clone(),
+            "spawn_team",
+            function_payload(json!({
+                "members": [
+                    {"name": "planner", "task": "plan the work"},
+                    {"name": "worker", "task": "execute the task"}
+                ]
+            })),
+        ))
+        .await
+        .expect("spawn_team should succeed");
+    let ToolOutput::Function {
+        body: FunctionCallOutputBody::Text(spawn_content),
+        ..
+    } = spawn_output
+    else {
+        panic!("expected function output");
+    };
+    let spawn_result: SpawnTeamResult =
+        serde_json::from_str(&spawn_content).expect("spawn_team result should be json");
+
+    let planner = spawn_result
+        .members
+        .iter()
+        .find(|member| member.name == "planner")
+        .expect("planner should exist");
+    let worker = spawn_result
+        .members
+        .iter()
+        .find(|member| member.name == "worker")
+        .expect("worker should exist");
+    let planner_id = agent_id(&planner.agent_id).expect("valid planner agent id");
+    let worker_id = agent_id(&worker.agent_id).expect("valid worker agent id");
+
+    manager
+        .agent_control()
+        .shutdown_agent(planner_id)
+        .await
+        .expect("shutdown planner");
+
+    MultiAgentHandler
+        .handle(invocation(
+            session.clone(),
+            turn.clone(),
+            "wait_team",
+            function_payload(json!({
+                "team_id": spawn_result.team_id,
+                "mode": "any",
+                "timeout_ms": 1_000
+            })),
+        ))
+        .await
+        .expect("wait_team should succeed");
+
+    let waiting_end = timeout(Duration::from_secs(5), async {
+        loop {
+            let event = rx.recv().await.expect("event should be received");
+            match event.msg {
+                codex_protocol::protocol::EventMsg::CollabWaitingEnd(ev)
+                    if ev.call_id == "team/wait:call-1" =>
+                {
+                    break ev;
+                }
+                _ => {}
+            }
+        }
+    })
+    .await
+    .expect("wait_team should emit a CollabWaitingEnd event");
+
+    let worker_status = waiting_end
+        .agent_statuses
+        .iter()
+        .find(|entry| entry.thread_id == worker_id)
+        .map(|entry| &entry.status)
+        .expect("worker should have a status entry");
+    assert!(!matches!(worker_status, &AgentStatus::NotFound));
+
+    manager
+        .agent_control()
+        .shutdown_agent(worker_id)
+        .await
+        .expect("shutdown worker");
+    remove_team_record(session.conversation_id, &spawn_result.team_id)
+        .expect("team record should be removed");
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/tools/handlers/multi_agents/wait_team.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/wait_team.rs
@@ -112,7 +112,20 @@ pub async fn handle(
         .iter()
         .cloned()
         .collect::<HashMap<_, _>>();
-    let agent_statuses = team_member_status_entries(&team.members, &final_statuses);
+    let mut reported_statuses = final_statuses.clone();
+    for member in &team.members {
+        if reported_statuses.contains_key(&member.agent_id) {
+            continue;
+        }
+        let status = session
+            .services
+            .agent_control
+            .get_status(member.agent_id)
+            .await;
+        reported_statuses.insert(member.agent_id, status);
+    }
+
+    let agent_statuses = team_member_status_entries(&team.members, &reported_statuses);
     session
         .send_event(
             &turn,
@@ -120,7 +133,7 @@ pub async fn handle(
                 sender_thread_id: session.conversation_id,
                 call_id: event_call_id,
                 agent_statuses,
-                statuses: final_statuses.clone(),
+                statuses: reported_statuses.clone(),
             }
             .into(),
         )
@@ -147,16 +160,10 @@ pub async fn handle(
 
     let mut member_statuses = Vec::with_capacity(team.members.len());
     for member in &team.members {
-        let state = match final_statuses.get(&member.agent_id) {
-            Some(state) => state.clone(),
-            None => {
-                session
-                    .services
-                    .agent_control
-                    .get_status(member.agent_id)
-                    .await
-            }
-        };
+        let state = reported_statuses
+            .get(&member.agent_id)
+            .cloned()
+            .unwrap_or(AgentStatus::NotFound);
         member_statuses.push(WaitTeamMemberStatus {
             name: member.name.clone(),
             agent_id: member.agent_id.to_string(),

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -117,11 +117,15 @@ use toml::Value as TomlValue;
 async fn test_config() -> Config {
     // Use base defaults to avoid depending on host state.
     let codex_home = std::env::temp_dir();
-    ConfigBuilder::default()
+    let mut config = ConfigBuilder::default()
         .codex_home(codex_home.clone())
         .build()
         .await
-        .expect("config")
+        .expect("config");
+    if config.model_provider.is_openai() {
+        config.model_provider.base_url = None;
+    }
+    config
 }
 
 fn invalid_value(candidate: impl Into<String>, allowed: impl Into<String>) -> ConstraintError {

--- a/codex-rs/tui/src/multi_agents.rs
+++ b/codex-rs/tui/src/multi_agents.rs
@@ -438,7 +438,7 @@ fn status_summary_spans(status: &AgentStatus) -> Vec<Span<'static>> {
             spans
         }
         AgentStatus::Shutdown => vec![Span::from("Shutdown").dim()],
-        AgentStatus::NotFound => vec![Span::from("Not found").red()],
+        AgentStatus::NotFound => vec![Span::from("Unavailable").dim()],
     }
 }
 
@@ -459,6 +459,8 @@ mod tests {
             .expect("valid robie thread id");
         let bob_id = ThreadId::from_string("00000000-0000-0000-0000-000000000003")
             .expect("valid bob thread id");
+        let alice_id = ThreadId::from_string("00000000-0000-0000-0000-000000000004")
+            .expect("valid alice thread id");
 
         let spawn = spawn_end(CollabAgentSpawnEndEvent {
             call_id: "call-spawn".to_string(),
@@ -497,6 +499,7 @@ mod tests {
             AgentStatus::Completed(Some("39916800".to_string())),
         );
         statuses.insert(bob_id, AgentStatus::Errored("tool timeout".to_string()));
+        statuses.insert(alice_id, AgentStatus::NotFound);
         let finished = waiting_end(CollabWaitingEndEvent {
             sender_thread_id,
             call_id: "call-wait".to_string(),
@@ -512,6 +515,12 @@ mod tests {
                     agent_nickname: Some("Bob".to_string()),
                     agent_role: Some("worker".to_string()),
                     status: AgentStatus::Errored("tool timeout".to_string()),
+                },
+                CollabAgentStatusEntry {
+                    thread_id: alice_id,
+                    agent_nickname: Some("Alice".to_string()),
+                    agent_role: Some("worker".to_string()),
+                    status: AgentStatus::NotFound,
                 },
             ],
             statuses,

--- a/codex-rs/tui/src/snapshots/codex_tui__multi_agents__tests__collab_agent_transcript.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__multi_agents__tests__collab_agent_transcript.snap
@@ -13,5 +13,6 @@ expression: snapshot
 • Finished waiting
   └ Robie [explorer]: Completed - 39916800
     Bob [worker]: Error - tool timeout
+    Alice [worker]: Unavailable
 
 • Closed Robie [explorer]

--- a/codex-rs/tui/src/status/tests.rs
+++ b/codex-rs/tui/src/status/tests.rs
@@ -24,11 +24,15 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 
 async fn test_config(temp_home: &TempDir) -> Config {
-    ConfigBuilder::default()
+    let mut config = ConfigBuilder::default()
         .codex_home(temp_home.path().to_path_buf())
         .build()
         .await
-        .expect("load config")
+        .expect("load config");
+    if config.model_provider.is_openai() {
+        config.model_provider.base_url = None;
+    }
+    config
 }
 
 fn test_auth_manager(config: &Config) -> AuthManager {


### PR DESCRIPTION
Fixes misleading 'Not found' statuses when wait_team(mode=any) returns early; render NotFound as neutral Unavailable in TUI; add regression + snapshots.