### PR TITLE
test(core): stabilize realtime startup context websocket ordering

### DIFF
--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -830,6 +830,7 @@ async fn conversation_startup_context_falls_back_to_workspace_map() -> Result<()
     let test = builder.build_with_websocket_server(&server).await?;
     fs::create_dir_all(test.workspace_path("codex-rs/core"))?;
     fs::write(test.workspace_path("notes.txt"), "workspace marker")?;
+    assert!(server.wait_for_handshakes(1, Duration::from_secs(2)).await);
 
     test.codex
         .submit(Op::RealtimeConversationStart(ConversationStartParams {


### PR DESCRIPTION
## Summary
- wait for the startup websocket prewarm handshake before starting realtime conversation in the workspace-map fallback test
- keep the existing production behavior unchanged and only stabilize the connection ordering assumption in the test

## Validation
- cargo test -p codex-core realtime_conversation -- --test-threads=1
- cargo test -q -p codex-core conversation_startup_context_falls_back_to_workspace_map -- --test-threads=1 (8 consecutive runs)

## Context
This follows main run 22821026552, where `conversation_startup_context_falls_back_to_workspace_map` failed because the test read the wrong websocket connection when startup prewarm raced with realtime conversation startup.