### PR TITLE
build(release): restore musl release link args

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -536,8 +536,9 @@ jobs:
           echo "CARGO_BUILD_RUSTFLAGS=" >> "$GITHUB_ENV"
           echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS=" >> "$GITHUB_ENV"
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS=" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS=" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS=" >> "$GITHUB_ENV"
+          musl_rustflags="-C link-arg=-lm -C link-arg=-lgcc_eh"
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS=${musl_rustflags}" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS=${musl_rustflags}" >> "$GITHUB_ENV"
 
           sanitize_flags() {
             local input="$1"


### PR DESCRIPTION
Problem:
The v1.2.5 tag rust-release run fails only on ubuntu-22.04 x86_64-unknown-linux-musl-legacy during Cargo build. The failed link uses -nodefaultlibs but the release job clears musl target rustflags entirely, so it drops the -lm / -lgcc_eh link args that the earlier musl build section in this workflow already keeps.

Why this is the right fix:
This makes the tag release job use the same musl target link args as the already-working musl build path in the same workflow. It is the narrowest change that matches the observed undefined symbols (log/pow/exp/sinf and __gcc_personality_v0).

What changed:
- In rust-release.yml release musl sanitizer clearing step, restore:
  -C link-arg=-lm
  -C link-arg=-lgcc_eh

Verification:
- Inspected failed job 66234767421 from run 22836809553
- Confirmed failure occurs in Cargo build link step with -nodefaultlibs
- Confirmed missing symbols match absent libm/libgcc_eh
- Confirmed same workflow already applies these musl rustflags in its earlier musl path
- Ran git diff --check locally