### PR TITLE
build(release): restore legacy musl cargo linker

### DIFF
--- a/.github/scripts/install-musl-build-tools.sh
+++ b/.github/scripts/install-musl-build-tools.sh
@@ -254,17 +254,14 @@ echo "${target_cxx_var}=${cxx}" >> "$GITHUB_ENV"
 
 cargo_linker_var="CARGO_TARGET_${TARGET^^}_LINKER"
 cargo_linker_var="${cargo_linker_var//-/_}"
-cargo_linker="${musl_linker}"
-if [[ "${LEGACY_MUSL:-}" != "true" ]]; then
-  cargo_linker_wrapper="${tool_root}/cargo-linker"
-  cat >"${cargo_linker_wrapper}" <<EOF
+cargo_linker_wrapper="${tool_root}/cargo-linker"
+cat >"${cargo_linker_wrapper}" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 exec "${musl_linker}" "\$@" -lm -lgcc_eh
 EOF
-  chmod +x "${cargo_linker_wrapper}"
-  cargo_linker="${cargo_linker_wrapper}"
-fi
+chmod +x "${cargo_linker_wrapper}"
+cargo_linker="${cargo_linker_wrapper}"
 echo "${cargo_linker_var}=${cargo_linker}" >> "$GITHUB_ENV"
 
 echo "CMAKE_C_COMPILER=${cc}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- route legacy musl release builds through the same cargo-linker wrapper as regular musl builds
- keep the wrapper appending -lm and -lgcc_eh at the end of the linker command

## Testing
- bash -n .github/scripts/install-musl-build-tools.sh
- git diff --check