### PR TITLE
build: align legacy musl release rustflags

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -202,10 +202,6 @@ jobs:
           echo "CARGO_BUILD_RUSTFLAGS=" >> "$GITHUB_ENV"
           echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS=" >> "$GITHUB_ENV"
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS=" >> "$GITHUB_ENV"
-          musl_rustflags="-C link-arg=-lm -C link-arg=-lgcc_eh"
-          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS=${musl_rustflags}" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS=${musl_rustflags}" >> "$GITHUB_ENV"
-
           sanitize_flags() {
             local input="$1"
             input="${input//-fsanitize=undefined/}"


### PR DESCRIPTION
## Summary
- remove release-only musl target rustflags injection
- align legacy musl release path with the passing rust-ci path
- keep the cargo-linker wrapper and legacy release throttling unchanged

## Testing
- git diff --check