### PR TITLE
build: relax legacy musl codegen overrides

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -550,8 +550,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "CARGO_PROFILE_RELEASE_LTO=off" >> "$GITHUB_ENV"
-          echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16" >> "$GITHUB_ENV"
           echo "CARGO_BUILD_JOBS=1" >> "$GITHUB_ENV"
       - name: Cargo build
         shell: bash


### PR DESCRIPTION
## Summary
- keep the 22.04 release runner
- stop overriding legacy musl release LTO and codegen units
- keep legacy build single-threaded to limit resource churn

## Testing
- git diff --check